### PR TITLE
User controller to accept email or username

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -3,9 +3,25 @@ const TokenGenerator = require("../models/token_generator");
 
 const UserController = {
     Index: (req, res) => {
+        const userName = req.body.userName;
         const email = req.body.email;
 
-        User.findOne({ email: email }).then(async (user) => {
+        let searchValue = "";
+        let searchKey = "";
+        let userDetails = {};
+
+        if (userName) {
+          searchKey = 'userName';
+          searchValue = userName;
+        }
+        else {
+          searchKey = 'email';
+          searchValue = email;
+        };
+        
+        userDetails[searchKey] = searchValue;
+
+        User.findOne(userDetails).then(async (user) => {
             if (!user) {
               console.log("auth error: user not found")
               res.status(401).json({ message: "auth error" });

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -3,8 +3,8 @@ const TokenGenerator = require("../models/token_generator");
 
 const UserController = {
     Index: (req, res) => {
-        const userName = req.body.userName;
-        const email = req.body.email;
+        const userName = req.query.username;
+        const email = req.query.email;
 
         let userDetails = {};
 

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -6,18 +6,10 @@ const UserController = {
         const userName = req.body.userName;
         const email = req.body.email;
 
-        let searchValue = "";
-        let searchKey = "";
         let userDetails = {};
 
-        if (userName) {
-          searchKey = 'userName';
-          searchValue = userName;
-        }
-        else {
-          searchKey = 'email';
-          searchValue = email;
-        };
+        const searchKey = userName ? 'userName' : 'email';
+        const searchValue = userName || email;
         
         userDetails[searchKey] = searchValue;
 

--- a/api/spec/controllers/user.spec.js
+++ b/api/spec/controllers/user.spec.js
@@ -31,8 +31,8 @@ describe("/user", () => {
         await User.deleteMany({});
       })
 
-      describe("GET, when token is present", () => {
-        test("returns user first name, last name and username for a given user password", async () => {
+      describe("GET with email when token is present", () => {
+        test("returns user first name, last name and username for a given email", async () => {
             const email = "test@test.com";
             let response = await request(app)
                 .get("/user")
@@ -72,7 +72,7 @@ describe("/user", () => {
         })
       })
 
-      describe("GET, when token is missing", () => {
+      describe("GET with email when token is missing", () => {
         test("returns an error", async () =>{
           const email = "test@test.com";
           let response = await request(app)
@@ -109,5 +109,102 @@ describe("/user", () => {
 
       })
 
+      describe("GET, when email given doesn't exist", () => {
+        test("returns an error", async () =>{
+          const email = "wrongemail@test.com";
+          let response = await request(app)
+              .get("/user")
+              .set("Authorization", `Bearer ${token}`)
+              .send({
+                  email: email,
+                  token: token});
+          let errMessage = response.body.message;
+          expect(errMessage).toEqual("auth error");
+        })
 
+        test("the response code is 401", async () =>{
+          const email = "wrongemail@test.com";
+          let response = await request(app)
+              .get("/user")
+              .set("Authorization", `Bearer ${token}`)
+              .send({
+                  email: email,
+                  token: token});
+          expect(response.status).toEqual(401);
+        })
+
+        test("does not return a new token", async () =>{
+          const email = "wrongemail@test.com";
+          let response = await request(app)
+              .get("/user")
+              .set("Authorization", `Bearer ${token}`)
+              .send({
+                  email: email,
+                  token: token});
+          expect(response.body.token).toEqual(undefined);
+        })
+
+      })
+      
+
+      describe("GET with userName when token is present", () => {
+        test("returns user first name and last name for a given userName", async () => {
+            const userName = "testy";
+            let response = await request(app)
+                .get("/user")
+                .set("Authorization", `Bearer ${token}`)
+                .send({
+                    userName: userName,
+                    token: token});
+            let userDetails = response.body.user;
+            expect(userDetails.firstName).toEqual("Test");
+            expect(userDetails.lastName).toEqual("Testson");
+        })
+    
+        test("the response code is 200", async () => {
+          const userName = "testy";
+          let response = await request(app)
+              .get("/user")
+              .set("Authorization", `Bearer ${token}`)
+              .send({
+                  userName: userName,
+                  token: token});
+          let userDetails = response.body.user;
+          expect(response.status).toEqual(200);
+        })
+    
+        test("returns a new token", async () => {
+          const userName = "testy";
+          let response = await request(app)
+              .get("/user")
+              .set("Authorization", `Bearer ${token}`)
+              .send({
+                  userName: userName,
+                  token: token});
+        let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
+        let originalPayload = JWT.decode(token, process.env.JWT_SECRET);
+        expect(newPayload.iat > originalPayload.iat).toBeTruthy();
+        })
+      })
+
+
+      describe("GET with userName and email when token is present", () => {
+        test("returns user first name and last name for a given userName", async () => {
+            const userName = "testy";
+            const email = "test@test.com";
+            let response = await request(app)
+                .get("/user")
+                .set("Authorization", `Bearer ${token}`)
+                .send({
+                    userName: userName,
+                    email: email,
+                    token: token});
+            let userDetails = response.body.user;
+            expect(userDetails.firstName).toEqual("Test");
+            expect(userDetails.lastName).toEqual("Testson");
+        })
+    
+      })
+
+  
 });

--- a/api/spec/controllers/user.spec.js
+++ b/api/spec/controllers/user.spec.js
@@ -31,180 +31,71 @@ describe("/user", () => {
         await User.deleteMany({});
       })
 
-      describe("GET with email when token is present", () => {
-        test("returns user first name, last name and username for a given email", async () => {
-            const email = "test@test.com";
+      describe("GET with username when token is present and response code is 200", () => {
+        test("returns user first name, last name and username for a given username", async () => {
             let response = await request(app)
-                .get("/user")
-                .set("Authorization", `Bearer ${token}`)
-                .send({
-                    email: email,
-                    token: token});
+                .get("/user?username=testy")
+                .set("Authorization", `Bearer ${token}`);
             let userDetails = response.body.user;
             expect(userDetails.firstName).toEqual("Test");
             expect(userDetails.lastName).toEqual("Testson");
             expect(userDetails.userName).toEqual("testy");
-        })
-    
-        test("the response code is 200", async () => {
-          const email = "test@test.com";
-          let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  email: email,
-                  token: token});
-          let userDetails = response.body.user;
-          expect(response.status).toEqual(200);
+            expect(response.status).toEqual(200);
         })
     
         test("returns a new token", async () => {
-          const email = "test@test.com";
           let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  email: email,
-                  token: token});
+              .get("/user?username=testy")
+              .set("Authorization", `Bearer ${token}`);
         let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
         let originalPayload = JWT.decode(token, process.env.JWT_SECRET);
         expect(newPayload.iat > originalPayload.iat).toBeTruthy();
         })
       })
 
-      describe("GET with email when token is missing", () => {
+      describe("GET with username when token is missing", () => {
         test("returns an error", async () =>{
-          const email = "test@test.com";
           let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer `)
-              .send({
-                  email: email,
-                  token: token});
+              .get("/user?username=testy")
+              .set("Authorization", `Bearer `);
           let errMessage = response.body.message;
           expect(errMessage).toEqual("auth error");
         })
 
         test("the response code is 401", async () =>{
-          const email = "test@test.com";
           let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer `)
-              .send({
-                  email: email,
-                  token: token});
+              .get("/user?username=testy")
+              .set("Authorization", `Bearer `);
           expect(response.status).toEqual(401);
+          
         })
 
         test("does not return a new token", async () =>{
-          const email = "test@test.com";
           let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer `)
-              .send({
-                  email: email,
-                  token: token});
+              .get("/user?username=testy")
+              .set("Authorization", `Bearer `);
           expect(response.body.token).toEqual(undefined);
         })
 
       })
 
-      describe("GET, when email given doesn't exist", () => {
+      describe("GET, when username given doesn't exist", () => {
         test("returns an error", async () =>{
-          const email = "wrongemail@test.com";
           let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  email: email,
-                  token: token});
+              .get("/user?username=wrongtesty")
+              .set("Authorization", `Bearer ${token}`);
           let errMessage = response.body.message;
           expect(errMessage).toEqual("auth error");
-        })
-
-        test("the response code is 401", async () =>{
-          const email = "wrongemail@test.com";
-          let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  email: email,
-                  token: token});
           expect(response.status).toEqual(401);
         })
 
         test("does not return a new token", async () =>{
-          const email = "wrongemail@test.com";
           let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  email: email,
-                  token: token});
+              .get("/user?username=wrongtesty")
+              .set("Authorization", `Bearer ${token}`);      
           expect(response.body.token).toEqual(undefined);
         })
 
       })
-      
-
-      describe("GET with userName when token is present", () => {
-        test("returns user first name and last name for a given userName", async () => {
-            const userName = "testy";
-            let response = await request(app)
-                .get("/user")
-                .set("Authorization", `Bearer ${token}`)
-                .send({
-                    userName: userName,
-                    token: token});
-            let userDetails = response.body.user;
-            expect(userDetails.firstName).toEqual("Test");
-            expect(userDetails.lastName).toEqual("Testson");
-        })
-    
-        test("the response code is 200", async () => {
-          const userName = "testy";
-          let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  userName: userName,
-                  token: token});
-          let userDetails = response.body.user;
-          expect(response.status).toEqual(200);
-        })
-    
-        test("returns a new token", async () => {
-          const userName = "testy";
-          let response = await request(app)
-              .get("/user")
-              .set("Authorization", `Bearer ${token}`)
-              .send({
-                  userName: userName,
-                  token: token});
-        let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
-        let originalPayload = JWT.decode(token, process.env.JWT_SECRET);
-        expect(newPayload.iat > originalPayload.iat).toBeTruthy();
-        })
-      })
-
-
-      describe("GET with userName and email when token is present", () => {
-        test("returns user first name and last name for a given userName", async () => {
-            const userName = "testy";
-            const email = "test@test.com";
-            let response = await request(app)
-                .get("/user")
-                .set("Authorization", `Bearer ${token}`)
-                .send({
-                    userName: userName,
-                    email: email,
-                    token: token});
-            let userDetails = response.body.user;
-            expect(userDetails.firstName).toEqual("Test");
-            expect(userDetails.lastName).toEqual("Testson");
-        })
-    
-      })
-
   
 });


### PR DESCRIPTION
controller/user

updated code to accept params as query params instead of body params
also updated to accept either username or email (but have not tested email as expect it may become redundant

updated tests in user.spec, all GREEN